### PR TITLE
Added support for listening to MDNS/service announcements.

### DIFF
--- a/Zeroconf.RT/NetworkInterface.cs
+++ b/Zeroconf.RT/NetworkInterface.cs
@@ -157,5 +157,10 @@ namespace Zeroconf
                 writer.DetachStream();
             }
         }
+
+        public Task ListenForAnnouncementsAsync(Action<AdapterInformation, string, byte[]> callback, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException("Windows RT does not support socket address reuse, which makes listening virtually impossible, as most users have browsers and Apple Bonjour running which already listens to 5353");
+        }
     }
 }

--- a/Zeroconf.Shared/AdapterInformation.cs
+++ b/Zeroconf.Shared/AdapterInformation.cs
@@ -1,0 +1,29 @@
+﻿namespace Zeroconf
+{
+    public class AdapterInformation
+    {
+        private readonly string m_address;
+        private readonly string m_name;
+
+        public AdapterInformation(string address, string name)
+        {
+            m_address = address;
+            m_name = name;
+        }
+
+        public string Address
+        {
+            get { return m_address; }
+        }
+
+        public string Name
+        {
+            get { return m_name; }
+        }
+
+        public override string ToString()
+        {
+            return string.Format("{0}: {1}", Name, Address);
+        }
+    }
+}

--- a/Zeroconf.Shared/Dns/Response.cs
+++ b/Zeroconf.Shared/Dns/Response.cs
@@ -265,5 +265,10 @@ namespace Heijden.DNS
 				return list.ToArray();
 			}
 		}
+
+        public bool IsQueryResponse
+        {
+            get { return header.QR; }
+        }
 	}
 }

--- a/Zeroconf.Shared/INetworkInterface.cs
+++ b/Zeroconf.Shared/INetworkInterface.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,5 +12,7 @@ namespace Zeroconf
                                  int retryDelayMilliseconds,
                                  Action<string, byte[]> onResponse,
                                  CancellationToken cancellationToken);
+
+        Task ListenForAnnouncementsAsync(Action<AdapterInformation, string, byte[]> callback, CancellationToken cancellationToken);
     }
 }

--- a/Zeroconf.Shared/Zeroconf.Shared.projitems
+++ b/Zeroconf.Shared/Zeroconf.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Zeroconf.Shared</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)AdapterInformation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AsyncLock.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Dns\Header.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Dns\Question.cs" />

--- a/Zeroconf.Shared/ZeroconfResolver.cs
+++ b/Zeroconf.Shared/ZeroconfResolver.cs
@@ -377,5 +377,15 @@ namespace Zeroconf
 
             return z;
         }
+
+        public static Task ListenForAnnouncementsAsync(Action<AdapterInformation, IZeroconfHost> callback, CancellationToken cancellationToken)
+        {
+            return NetworkInterface.ListenForAnnouncementsAsync((adapter, address, buffer) =>
+            {
+                var response = new Response(buffer);
+                if (response.IsQueryResponse)
+                    callback(adapter, ResponseToZeroconf(response, address));
+            }, cancellationToken);
+        }
     }
 }

--- a/ZeroconfTest.NetFx/MainWindow.xaml
+++ b/ZeroconfTest.NetFx/MainWindow.xaml
@@ -1,10 +1,28 @@
 ﻿<Window x:Class="ZeroconfTest.NetFx.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="MainWindow" Height="350" Width="525">
+        Title="MainWindow" Height="600" Width="800"
+        Closed="OnWindowClosed">
     <Grid>
-        <Button Content="Resolve" HorizontalAlignment="Left" Margin="66,44,0,0" VerticalAlignment="Top" Width="75" Click="Button_Click"/>
-        <Button Content="Browse" HorizontalAlignment="Left" Margin="66,80,0,0" VerticalAlignment="Top" Width="75" Click="Browse_Click"/>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <StackPanel Orientation="Vertical" Width="75" Grid.Column="0" Margin="5,5,0,5">
+            <StackPanel.Resources>
+                <Style TargetType="Button">
+                    <Setter Property="Margin" Value="5,0,0,5"/>
+                </Style>
+                <Style TargetType="ToggleButton">
+                    <Setter Property="Margin" Value="5,0,0,5"/>
+                </Style>
+            </StackPanel.Resources>
+            <Button Content="Resolve" HorizontalAlignment="Stretch" VerticalAlignment="Top" Click="Button_Click"/>
+            <Button Content="Browse" HorizontalAlignment="Stretch" VerticalAlignment="Top" Click="Browse_Click"/>
+            <ToggleButton Content="Listen" x:Name="ListenButton" HorizontalAlignment="Stretch" VerticalAlignment="Top" Click="StartStopListener_Click"/>
+        </StackPanel>
 
+        <TextBox Grid.Column="1" x:Name="Log" TextWrapping="Wrap" Text="" AcceptsReturn="True" IsReadOnly="True"
+                 VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" Margin="5"/>
     </Grid>
 </Window>

--- a/ZeroconfTest.NetFx/MainWindow.xaml.cs
+++ b/ZeroconfTest.NetFx/MainWindow.xaml.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Documents;
 using System.Windows.Input;
@@ -13,6 +15,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using System.Windows.Threading;
 using Zeroconf;
 
 namespace ZeroconfTest.NetFx
@@ -31,7 +34,7 @@ namespace ZeroconfTest.NetFx
         async void Button_Click(object sender, RoutedEventArgs e)
         {
 
-            //Action<IZeroconfRecord> onMessage = record => Console.WriteLine("On Message: {0}", record);
+            //Action<IZeroconfRecord> onMessage = record => Console.WriteLogLine("On Message: {0}", record);
 
 
             var domains = await ZeroconfResolver.BrowseDomainsAsync();
@@ -40,7 +43,7 @@ namespace ZeroconfTest.NetFx
             // var responses = await ZeroconfResolver.ResolveAsync("_http._tcp.local.");
             
             foreach (var resp in responses)
-                Console.WriteLine(resp);
+                WriteLogLine(resp.ToString());
         }
 
         async void Browse_Click(object sender, RoutedEventArgs e)
@@ -49,11 +52,79 @@ namespace ZeroconfTest.NetFx
             
             foreach (var service in responses)
             {
-                Console.WriteLine(service.Key);
+                WriteLogLine(service.Key);
 
                 foreach (var host in service)
-                    Console.WriteLine("\tIP: " + host);
+                    WriteLogLine("\tIP: " + host);
 
+            }
+        }
+
+        private void WriteLogLine(string text, params object[] args)
+        {
+            if (Log.Dispatcher.CheckAccess())
+            {
+                Log.AppendText(string.Format(text, args) + "\r\n");
+                Log.ScrollToEnd();
+            }
+            else
+            {
+                Log.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(() => WriteLogLine(text, args)));
+            }
+        }
+
+        private void OnAnnouncement(AdapterInformation info, IZeroconfHost host)
+        {
+            Log.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(() =>
+            {
+                WriteLogLine("---- Announced on {0} ({1}) ----", info.Name, info.Address);
+                WriteLogLine(host.ToString());
+            }));
+        }
+
+        private void OnWindowClosed(object sender, EventArgs e)
+        {
+            if (m_listenTask != null)
+            {
+                m_cancellationTokenSource.Cancel();
+
+                try
+                {
+                    m_listenTask.Wait();
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+            }
+        }
+
+        private CancellationTokenSource m_cancellationTokenSource;
+        private Task m_listenTask;
+
+        private async void StartStopListener_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                ListenButton.IsEnabled = false;
+
+                if (m_listenTask != null)
+                {
+                    m_cancellationTokenSource.Cancel();
+                    await m_listenTask;
+                    m_cancellationTokenSource.Dispose();
+                    m_cancellationTokenSource = null;
+                    m_listenTask = null;
+                }
+                else
+                {
+                    m_cancellationTokenSource = new CancellationTokenSource();
+                    m_listenTask = ZeroconfResolver.ListenForAnnouncementsAsync(OnAnnouncement, m_cancellationTokenSource.Token);
+                }
+            }
+            finally
+            {
+                ListenButton.IsEnabled = true;
             }
         }
     }


### PR DESCRIPTION
I have added support for listening for MDNS service announcements. It should work for Xamarin (Android, iOS), .NET Framework, and .NET Core. I have only tested it on .NET Framework.

I did try to make it work for Windows RT, but it is not possible to specify address reuse on UDP sockets in Windows RT. This is a problem when there are other processes on the host machine that is listening to the MDNS port (Chrome and Bonjour are two processes that do on my machine).