### PR TITLE
Fixed scanTime bug: TimeSpan.Milliseconds to scanTime.TotalMilliseconds

### DIFF
--- a/Zeroconf.DotNetCore/NetworkInterface.cs
+++ b/Zeroconf.DotNetCore/NetworkInterface.cs
@@ -95,7 +95,7 @@ namespace Zeroconf
                                                       true);
                         socket.SetSocketOption(SocketOptionLevel.Socket,
                                                       SocketOptionName.ReceiveTimeout,
-                                                      scanTime.Milliseconds);
+                                                      (int)scanTime.TotalMilliseconds);
                         client.ExclusiveAddressUse = false;
 
 


### PR DESCRIPTION
TimeSpan.Milliseconds only gives you the millisecond component of the time. The bug would treat a timeout of 1.1 seconds as 100 milliseconds 