### PR TITLE
fix overwriting multiple responses for same IP

### DIFF
--- a/Zeroconf/ZeroconfResolver.cs
+++ b/Zeroconf/ZeroconfResolver.cs
@@ -38,18 +38,19 @@ namespace Zeroconf
                     {
                         var resp = new Response(buffer);
                         var firstPtr = resp.RecordsPTR.FirstOrDefault();
-                        string name = firstPtr?.PTRDNAME.Split('.')[0] ?? "";
-                        string debugName = name == "" ? "" : "Name: " + name + ", ";
-                        Debug.WriteLine($"IP: {address}, {debugName}Bytes: {buffer.Length}, IsResponse: {resp.header.QR}");
+                        var name = firstPtr?.PTRDNAME.Split('.')[0] ?? string.Empty;
+
+                        Debug.WriteLine($"IP: {address}, {(string.IsNullOrEmpty(name) ? string.Empty : $"Name: {name}, ")}Bytes: {buffer.Length}, IsResponse: {resp.header.QR}");
 
                         if (resp.header.QR)
                         {
+                            var key = $"{address}{(string.IsNullOrEmpty(name) ? "" : $": {name}")}";
                             lock (dict)
                             {
-                                dict[address + (name == "" ? "" : ":" + name)] = resp;
+                                dict[key] = resp;
                             }
 
-                            callback?.Invoke(address, resp);
+                            callback?.Invoke(key, resp);
                         }
                     };
 
@@ -124,7 +125,8 @@ namespace Zeroconf
                 {
                     Name = ptrRec.RR.NAME,
                     Port = srvRec.PORT,
-                    Ttl = (int)srvRec.RR.TTL
+                    Ttl = (int)srvRec.RR.TTL,
+
                 };
 
                 // There may be 0 or more text records - property sets

--- a/Zeroconf/ZeroconfResolver.cs
+++ b/Zeroconf/ZeroconfResolver.cs
@@ -38,14 +38,15 @@ namespace Zeroconf
                     {
                         var resp = new Response(buffer);
                         var firstPtr = resp.RecordsPTR.FirstOrDefault();
-                        var dn = firstPtr?.PTRDNAME.Split('.')[0] ?? "N/A";
-                        Debug.WriteLine($"IP: {address}, Name: {dn}, Bytes: {buffer.Length}, IsResponse: {resp.header.QR}");
+                        string name = firstPtr?.PTRDNAME.Split('.')[0] ?? "";
+                        string debugName = name == "" ? "" : "Name: " + name + ", ";
+                        Debug.WriteLine($"IP: {address}, {debugName}Bytes: {buffer.Length}, IsResponse: {resp.header.QR}");
 
                         if (resp.header.QR)
                         {
                             lock (dict)
                             {
-                                dict[$"{address}:{dn}"] = resp;
+                                dict[address + (name == "" ? "" : ":" + name)] = resp;
                             }
 
                             callback?.Invoke(address, resp);

--- a/Zeroconf/ZeroconfResolver.cs
+++ b/Zeroconf/ZeroconfResolver.cs
@@ -37,13 +37,15 @@ namespace Zeroconf
                     (address, buffer) =>
                     {
                         var resp = new Response(buffer);
-                        Debug.WriteLine($"IP: {address}, Bytes: {buffer.Length}, IsResponse: {resp.header.QR}");
+                        var firstPtr = resp.RecordsPTR.FirstOrDefault();
+                        var dn = firstPtr?.PTRDNAME.Split('.')[0] ?? "N/A";
+                        Debug.WriteLine($"IP: {address}, Name: {dn}, Bytes: {buffer.Length}, IsResponse: {resp.header.QR}");
 
                         if (resp.header.QR)
                         {
                             lock (dict)
                             {
-                                dict[address] = resp;
+                                dict[$"{address}:{dn}"] = resp;
                             }
 
                             callback?.Invoke(address, resp);


### PR DESCRIPTION
The `Dictionary<string,Response>` returned by `ZeroconfResolver.ResolveInternal` (used by `ZeroconfResolver.ResolveAsync`) only returns the last response for each IP address, even if the additional responses containing different services are received. Google Chromecast Audio devices return multiple responses if they are grouped into a casting group. Fixed Example (output from ZeroconfTest.NetFx project's "Resolve" button):

```
Id: 192.168.5.145, DisplayName: Chromecast-Audio-2647edab8e69032645cb37d20f772ae4, IPs: 192.168.5.145, Services: 1
Service: _googlecast._tcp.local. Port: 8009, TTL: 120, PropertySets: 1
Begin Property Set #0
-------------------
id = 2647edab8e69032645cb37d20f772ae4
cd = 0944EB59E159C74ED6713C7AB7BFA70E
rm = 
ve = 05
md = Chromecast Audio
ic = /setup/icon.png
fn = Living Room
ca = 2052
st = 0
bs = FA8FCA948506
nf = 1
rs = 
-------------------

Id: 192.168.5.145, DisplayName: Google-Cast-Group-5b368348ff4d45c89ea98ef30a192556, IPs: 192.168.5.145, Services: 1
Service: _googlecast._tcp.local. Port: 42418, TTL: 120, PropertySets: 1
Begin Property Set #0
-------------------
id = 5b368348-ff4d-45c8-9ea9-8ef30a192556
cd = 5b368348-ff4d-45c8-9ea9-8ef30a192556
rm = 
ve = 05
md = Google Cast Group
ic = /setup/icon.png
fn = Speaker Group
ca = 2084
st = 0
bs = FA8FCA948506
nf = 1
rs = 
-------------------
```
Before the fix, only the second entry appeared in the results from `ZeroconfResolver.ResolveAsync`. I used the DisplayName to key the Dictionary in addition to the IP address, but there may be a better ID to use--I'm not super familiar with the Zeroconf protocol. I used the similar method of getting the DisplayName as the existing `ZeroconfResolver.ResponseToZeroconf(...)` function.