### PR TITLE
Fix ResolverListener so that ServiceLost is called only after N successive failed pings

### DIFF
--- a/Zeroconf/ZeroConfResolver.Listener.cs
+++ b/Zeroconf/ZeroConfResolver.Listener.cs
@@ -98,8 +98,9 @@ namespace Zeroconf
                             {
                                 ServiceFound?.Invoke(this, host);
                                 newHosts.Add(keyValue);
-                                if (toRemove.ContainsKey(keyValue)) toRemove.Remove(keyValue);
                             }
+                            if (toRemove.ContainsKey(keyValue))
+                                toRemove.Remove(keyValue);
                         }
                     }
 


### PR DESCRIPTION
Currently the counter that count failed pings is not reset after a successfull ping
see #105 